### PR TITLE
Update v1 video with new export

### DIFF
--- a/videos.json
+++ b/videos.json
@@ -1,57 +1,57 @@
 {
-  "defaultVideoURL": "http://exhibits.storage.imaginary.org/ethics-vehicles-2/videos/v1/",
+  "defaultVideoURL": "http://exhibits.storage.imaginary.org/ethics-vehicles-2/videos/v1/hevc-main-yuv420p10le-rf0/",
   "videos": [
     {
       "name": "idle.mp4",
-      "checksum": "add357e9445077b6d858d8dd7368efb7541c98c76707b4a20ae15f60f959942c"
+      "checksum": "0739c3e54d49f27870c91a4796b825f04eb5c7ffc6a0b422ead5e26657d67ed4"
     },
     {
       "name": "scene_1_0.mp4",
-      "checksum": "80cc44833b3f0e5a48de66ac3da54db11d59a823d30afbad0d8a7b4d68c3d9e7"
+      "checksum": "3a1618a8718193817ccae16a9eaa3d4c9b99fe34e957a32e04d531306c1b3d7f"
     },
     {
       "name": "scene_1_1.mp4",
-      "checksum": "bb17fdc191ad7d595ef1139c430c33f74e0b052156756a3a2f625f4808e2179b"
+      "checksum": "3ec3bc4fd8771c218d0f088f854502595032fd618bc52542ae01eb1dd6cb214b"
     },
     {
       "name": "scene_1_2.mp4",
-      "checksum": "0cb8ff6d6ac889a47e4fb530c13aec50058e7833abef447825d69292d1ba2117"
+      "checksum": "13d2b7dbb402b4e7ab56deff335901a6608025a46482b541b595654a74f97110"
     },
     {
       "name": "scene_1_3.mp4",
-      "checksum": "8e6a85e1e5d060e2d7a9eb86323ef435ed6a07cf47dc649cf707e2fcdb633f8c"
+      "checksum": "41601526867ff3a0a68a0627a791b260580278853ffa1b79ffc38bc23be3e6d3"
     },
     {
       "name": "scene_2_0.mp4",
-      "checksum": "9debc6eee25fc414183e49f2c603fbb84438b34edf52fda2ec5f05ba54c29eaa"
+      "checksum": "d895845e3a30c7c96e0a89fcb131944815d0d1c0f8dab81698b2c2722e1e10de"
     },
     {
       "name": "scene_2_1.mp4",
-      "checksum": "2810d9ce1091042786e5b66ad4658ae442a5eebe67c51015eb912896b06b1318"
+      "checksum": "bf76567c2838453caec0cdb5cbc0ac9f511bb5808041961d822ea7e3c854d86d"
     },
     {
       "name": "scene_2_2.mp4",
-      "checksum": "7d5783b13990fe0c226a7994b1c025b52a772ea0a9f46ac066d6d0faf2cd7962"
+      "checksum": "8d748e6269514face950267e63f3b5cc3740c3a17c458219592d3e6a714a698d"
     },
     {
       "name": "scene_2_3.mp4",
-      "checksum": "7d5783b13990fe0c226a7994b1c025b52a772ea0a9f46ac066d6d0faf2cd7962"
+      "checksum": "8d748e6269514face950267e63f3b5cc3740c3a17c458219592d3e6a714a698d"
     },
     {
       "name": "scene_3_0.mp4",
-      "checksum": "9bc91b8aa2d4230cc1c092f52ad252aeeb1189963fcead66066dfc834d5d55f7"
+      "checksum": "066038e3fe842c9700ff6e99b83ae8236024865f9a871b204386b61af3115ddd"
     },
     {
       "name": "scene_3_1.mp4",
-      "checksum": "ec9fd44e04e76624c3bc7127c7f25e9a54cbd6ec721035e0cc100af95ac497d8"
+      "checksum": "12e5a44a86b98c395a56de2e9aa01d89fd46927b76bd690a8c2295e429957242"
     },
     {
       "name": "scene_3_2.mp4",
-      "checksum": "ffb4f040bda906cfcae00b40cd235b6388b87968ef43947943ee7b729290ce89"
+      "checksum": "ce56827a5eeb769044b9f14c0aa6ae02f428cf883d7be1d323a4a44335a4955d"
     },
     {
       "name": "scene_3_3.mp4",
-      "checksum": "5061145801da6c4efe32cf9762da704fcc66c91753fd7ce4017c8a8c0212326e"
+      "checksum": "32f37151dd78102952b16a80bc4bea1044d59f7a7b6af678a270a0b0de2d23a0"
     }
   ]
 }


### PR DESCRIPTION
The previous v1 exports did not work in Chrome on Linux (h.265 Main Rext yuv422p10le profile not supported). I uploaded new yuv420p10le exports, updated the download link and the hash sums. 